### PR TITLE
Halycon- Tip added for iron blocks

### DIFF
--- a/DTM/Halcyon/map.xml
+++ b/DTM/Halcyon/map.xml
@@ -8,6 +8,8 @@
     <author uuid="8242e55e-cc6a-458a-b272-a2b34918045f">funkystudios</author>
     <!-- funkystudios -->
 </authors>
+<broadcasts>
+    <tip after="1s"> Iron blocks are behind spawn! </tip>
 <teams>
     <team color="dark red" max="18">Red</team>
     <team color="dark purple" max="18">Purple</team>

--- a/DTM/Halcyon/map.xml
+++ b/DTM/Halcyon/map.xml
@@ -9,7 +9,8 @@
     <!-- funkystudios -->
 </authors>
 <broadcasts>
-    <tip after="1s"> Iron blocks are behind spawn! </tip>
+    <tip after="1s">Iron blocks are behind spawn!</tip>
+</broadcasts>
 <teams>
     <team color="dark red" max="18">Red</team>
     <team color="dark purple" max="18">Purple</team>


### PR DESCRIPTION
Tip added to tell players that iron blocks are behind their spawn point