### PR TITLE
Halcyon- Tip added for iron behind spawn

### DIFF
--- a/DTM/Standard/Halcyon/map.xml
+++ b/DTM/Standard/Halcyon/map.xml
@@ -12,6 +12,9 @@
     <team color="dark red" max="16">Red</team>
     <team color="dark purple" max="16">Purple</team>
    </teams>
+<broadcasts>
+    <tip after="1s">Iron blocks are behind spawn!</tip>
+</broadcasts>
 <kits>
     <kit name="spawn">
         <item slot="0" unbreakable="true">stone sword</item>

--- a/DTM/Standard/Halcyon/map.xml
+++ b/DTM/Standard/Halcyon/map.xml
@@ -13,7 +13,7 @@
     <team color="dark purple" max="16">Purple</team>
    </teams>
 <broadcasts>
-    <tip after="1s">Iron blocks are behind spawn!</tip>
+    <tip after="5s">Iron blocks are behind spawn!</tip>
 </broadcasts>
 <kits>
     <kit name="spawn">


### PR DESCRIPTION
Tip added to tell players theres iron blocks behind spawn when game starts