### PR TITLE
Add common compression format, OS files, and scaffold.yml to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,20 @@
 # Mac OSX generated files
 .DS_Store
 
-# ignore map files
+# Windows generated files
+Thumbs.db
+[Dd]esktop.ini
+
+# VS Code and Sublime generated files
+.vscode/*
+!.vscode/settings.json
+!.vscode/tasks.json
+!.vscode/launch.json
+!.vscode/extensions.json
+!.vscode/*.code-snippets
+*.sublime-workspace
+
+# Minecraft map files
 session.lock
 *.dat_old
 *.dat_mcr
@@ -11,8 +24,10 @@ session.lock
 uid.dat
 villages.dat
 mcedit_waypoints.dat
+scaffold.yml
 
-# misc
-Thumbs.db
+# Misc
 *.zip
+*.7z
+*.rar
 LICENSE.txt

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,6 @@
-# Mac OSX generated files
+# macOS generated files
 .DS_Store
 ._*
-
 
 # Windows generated files
 Thumbs.db

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 # Mac OSX generated files
 .DS_Store
+._*
+
 
 # Windows generated files
 Thumbs.db
@@ -30,4 +32,6 @@ scaffold.yml
 *.zip
 *.7z
 *.rar
+*.tar
+*.gz
 LICENSE.txt


### PR DESCRIPTION
* Added common Windows and macOS files that sometimes make its way into commits
* Added VS Code and Sublime settings file (since we started recommending it in the repository's readme)
* Added two more common file compression format (and two more common file archiving format)
* scaffold.yml since [Warzone maintains a fork of it](https://github.com/Warzone/Scaffold) and some map building servers are using this.