### PR TITLE
Kyoto - Remove duplicate gamemode tag

### DIFF
--- a/DTM/Standard/Kyoto/map.xml
+++ b/DTM/Standard/Kyoto/map.xml
@@ -1,7 +1,6 @@
 <map proto="1.4.0">
 <name>Kyoto</name>
-<version>1.1.1</version>
-<gamemode>dtm</gamemode>
+<version>1.1.2</version>
 <objective>Destroy the other team’s two monuments to win!</objective>
 <gamemode>dtm</gamemode>
 <authors>


### PR DESCRIPTION
This was causing the scoreboard to display the title as "DTM and DTM".

![image](https://user-images.githubusercontent.com/20259871/155861851-1841cb35-b3da-4c08-83c1-a5dd26c6feb2.png)
