### PR TITLE
[Dracula] Add golden apple to kill-rewards

### DIFF
--- a/KoTH/Standard/Dracula/map.xml
+++ b/KoTH/Standard/Dracula/map.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <map proto="1.3.5">
 <name>Dracula</name> 
-<version>1.0.3</version> 
+<version>1.0.4</version> 
 <objective>Be the first team to reach 650 points!</objective>
 <gamemode>koth</gamemode>
 <authors>
@@ -189,6 +189,7 @@
 <killreward>
     <item amount="4">gold nugget</item>
     <item amount="4">arrow</item>
+    <item amount="1">golden apple</item>
 </killreward>
 <itemremove>
     <item>leather helmet</item>


### PR DESCRIPTION
At the moment, it is extremely difficult and almost impossible to 1v2 on this map because there is simply no golden apples.
The potion of healing in the starting kit, doesn't seem to help much either, so I believe having golden apples will be a good way 
to fight more than one player without having to deal with low hearts betweeen fights.
