### PR TITLE
Serpent - tweak score limit and void region

### DIFF
--- a/Arcade/Serpent/map.xml
+++ b/Arcade/Serpent/map.xml
@@ -61,7 +61,7 @@
     <box points="1" filter="red-only" region="yellow-portal"/>
     <box points="1" filter="yellow-only" region="red-portal"/>
     <mercy>10</mercy>
-    <limit>15</limit>
+    <limit>14</limit>
 </score>
 <time result="score">10m</time>
 <!-- Filters -->
@@ -87,7 +87,7 @@
     <point id="yellow-spawn">5.5, 46, 0.5</point>
     <point id="red-spawn">83.5, 46, 0.5</point>
     <point id="obs-spawn">44.5, 64, 0.5</point>
-    <below id="void" y="25"/>
+    <below id="void" y="30"/>
     <!-- Applications -->
     <apply region="bridge-area" block="only-clay-in-map" message="You may only place or destroy stained clay blocks."/>
     <apply region="everywhere" block="never" message="You are not allowed to modify terrain here."/>

--- a/Arcade/Serpent/map.xml
+++ b/Arcade/Serpent/map.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <map proto="1.4.0" game="Bridge">
 <name>Serpent</name>
-<version>1.0.0</version>
+<version>1.0.1</version>
 <objective>Rush across the map with a bridge to get into a portal located below the enemy's spawn to score as many points as possible.</objective>
 <gamemode>arcade</gamemode>
 <gamemode>scorebox</gamemode>


### PR DESCRIPTION
### Map Name
> Serpent

### Update Changelog
- Adjusted hard score limit from `15` to `14`, per Wesdial's request.
- Moved the `void` region to start at y=30, putting it below the clay bridge for faster void death.

### Screenshots or Videos (if applicable)
n/a