### PR TITLE
Fix dying in Kilo Sumo, again

### DIFF
--- a/Arcade/Kilo Sumo/map.xml
+++ b/Arcade/Kilo Sumo/map.xml
@@ -40,16 +40,18 @@
         <game-mode>adventure</game-mode>
         <item slot="0" name="`cSUMO WEAPON" damage="1">ink sack</item>
         <helmet unbreakable="true" locked="true" color="B02E26">leather helmet</helmet>
-        <effect duration="1000000" amplifier="5">saturation</effect>
-        <effect duration="1000000" amplifier="1">regeneration</effect>
+        <effect duration="oo" amplifier="1">regeneration</effect>
     </kit>
     <!-- Blue Kit -->
     <kit id="blue-kit">
         <game-mode>adventure</game-mode>
         <item slot="0" name="`9SUMO WEAPON" damage="4">ink sack</item>
         <helmet unbreakable="true" locked="true" color="3C44AA">leather helmet</helmet>
-        <effect duration="1000000" amplifier="5">saturation</effect>
-        <effect duration="1000000" amplifier="1">instant_health</effect>
+        <effect duration="oo" amplifier="1">instant_health</effect>
+    </kit>
+    <!-- Void Kit -->
+    <kit id="void-kit" force="true">
+        <clear items="false" armor="false" effects="true"/>
     </kit>
 </kits>
 <!-- Platforms -->
@@ -104,8 +106,10 @@
     <cuboid id="first-platform" min="-11,80,-11" max="10,85,10"/>
     <cuboid id="second-platform" min="-25,65,-25" max="24,70,24"/>
     <cuboid id="third-platform" min="-11,37,-11" max="10,42,10"/>
+    <below id="void" y="20"/>
     <!-- Applications -->
     <apply block="never" message="You are not allowed to modify terrain here."/>
+    <apply region="void" kit="void-kit"/>
 </regions>
 <!-- Spawns -->
 <spawns>

--- a/Arcade/Kilo Sumo/map.xml
+++ b/Arcade/Kilo Sumo/map.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <map proto="1.4.0" game="Blitz: Sumo">
 <name>Kilo Sumo</name>
-<version>2.0.0</version>
+<version>2.0.1</version>
 <objective>Be the last team standing by throwing everyone off the platform!</objective>
 <gamemode>arcade</gamemode>
 <gamemode>blitz</gamemode>
@@ -40,14 +40,14 @@
         <game-mode>adventure</game-mode>
         <item slot="0" name="`cSUMO WEAPON" damage="1">ink sack</item>
         <helmet unbreakable="true" locked="true" color="B02E26">leather helmet</helmet>
-        <effect duration="oo" amplifier="1">regeneration</effect>
+        <effect duration="oo" amplifier="2">instant_health</effect>
     </kit>
     <!-- Blue Kit -->
     <kit id="blue-kit">
         <game-mode>adventure</game-mode>
         <item slot="0" name="`9SUMO WEAPON" damage="4">ink sack</item>
         <helmet unbreakable="true" locked="true" color="3C44AA">leather helmet</helmet>
-        <effect duration="oo" amplifier="1">instant_health</effect>
+        <effect duration="oo" amplifier="2">instant_health</effect>
     </kit>
     <!-- Void Kit -->
     <kit id="void-kit" force="true">


### PR DESCRIPTION
### Map Name
Kilo Sumo

### Update Changelog
- Fixed potion inconsistency (blue had `instant_health` while red had `regenerative`, allowing some red members to die in the game too early)
    - Changed duration from `1000000` to `oo` for true infinity.
- Removed redundant saturation effect since hunger was already disabled (see line 137-139).
- Created a void kit that will force-apply to any players falling past y=20, which will clear their instant health effect to allow for void death.

