### PR TITLE
Fix players getting stuck at spawns in SuperCUBE

### DIFF
--- a/CTF/Standard/SuperCUBE/map.xml
+++ b/CTF/Standard/SuperCUBE/map.xml
@@ -1,6 +1,7 @@
+<?xml version="1.0"?>
 <map proto="1.4.2">
 <name>SuperCUBE</name>
-<version>0.9</version>
+<version>0.10</version>
 <objective>Capture the enemy's flag as many times as possible in 12 minutes to win!</objective>
 <gamemode>ctf</gamemode>
 <time result="score" overtime="1m" max-overtime="2m">12m</time>
@@ -60,39 +61,44 @@
 <spawns safe="true">
     <default kit="default-kit">
         <region yaw="90">
-            <cylinder base="-68,25,33" radius="3" height="0"/>
+            <!-- <cylinder base="-68,25,33" radius="3" height="0"/> -->
+            <point>-68.5,25,33.5</point>
         </region>
     </default>
     <!-- blue -->
     <spawn team="blue" kit="spawn-kit">
         <region yaw="-90">
-            <cylinder base="-163,2,15" radius="2" height="1"/>
+            <!-- <cylinder base="-163,2,15" radius="2" height="1"/> -->
+            <point>-163.5,2,15.5</point>
         </region>
     </spawn>
     <spawn team="blue" kit="spawn-kit">
         <region yaw="-135">
-            <block>-150.5,4,57.5</block>
+            <point>-150.5,4,57.5</point>
         </region>
     </spawn>
     <spawn team="blue" kit="spawn-kit">
         <region yaw="-45">
-            <cylinder base="-166,2,-22" radius="2" height="1"/>
+            <!-- <cylinder base="-166,2,-22" radius="2" height="1"/> -->
+            <point>-166.5,2,-22.5</point>
         </region>
     </spawn>
     <!-- red -->
     <spawn team="red" kit="spawn-kit">
         <region yaw="90">
-            <cylinder base="26,2,51" radius="2" height="1"/>
+            <!-- <cylinder base="26,2,51" radius="2" height="1"/> -->
+            <point>26.5,2,51.5</point>
         </region>
     </spawn>
     <spawn team="red" kit="spawn-kit">
         <region yaw="45">
-            <block>13.5,4,9.5</block>
+            <point>13.5,4,9.5</point>
         </region>
     </spawn>
     <spawn team="red" kit="spawn-kit">
         <region yaw="135">
-            <cylinder base="29,2,89" radius="2" height="1"/>
+            <!-- <cylinder base="29,2,89" radius="2" height="1"/> -->
+            <point>29.5,2,89.5</point>
         </region>
     </spawn>
 </spawns>

--- a/CTF/Standard/SuperCUBE/map.xml
+++ b/CTF/Standard/SuperCUBE/map.xml
@@ -61,15 +61,15 @@
 <spawns safe="true">
     <default kit="default-kit">
         <region yaw="90">
-            <!-- <cylinder base="-68,25,33" radius="3" height="0"/> -->
-            <point>-68.5,25,33.5</point>
+            <cylinder base="-68.5,25,33.5" radius="3" height="0"/>
+            <!-- <point>-68.5,25,33.5</point> -->
         </region>
     </default>
     <!-- blue -->
     <spawn team="blue" kit="spawn-kit">
         <region yaw="-90">
-            <!-- <cylinder base="-163,2,15" radius="2" height="1"/> -->
-            <point>-163.5,2,15.5</point>
+            <cylinder base="-163.5,2,15.5" radius="2" height="0"/>
+            <!-- <point>-163.5,2,15.5</point> -->
         </region>
     </spawn>
     <spawn team="blue" kit="spawn-kit">
@@ -79,15 +79,15 @@
     </spawn>
     <spawn team="blue" kit="spawn-kit">
         <region yaw="-45">
-            <!-- <cylinder base="-166,2,-22" radius="2" height="1"/> -->
-            <point>-166.5,2,-22.5</point>
+            <cylinder base="-166.5,2,-22.5" radius="2" height="0"/>
+            <!-- <point>-166.5,2,-22.5</point> -->
         </region>
     </spawn>
     <!-- red -->
     <spawn team="red" kit="spawn-kit">
         <region yaw="90">
-            <!-- <cylinder base="26,2,51" radius="2" height="1"/> -->
-            <point>26.5,2,51.5</point>
+            <cylinder base="26.5,2,51.5" radius="2" height="0"/>
+            <!-- <point>26.5,2,51.5</point> -->
         </region>
     </spawn>
     <spawn team="red" kit="spawn-kit">
@@ -97,8 +97,8 @@
     </spawn>
     <spawn team="red" kit="spawn-kit">
         <region yaw="135">
-            <!-- <cylinder base="29,2,89" radius="2" height="1"/> -->
-            <point>29.5,2,89.5</point>
+            <cylinder base="29.5,2,89.5" radius="2" height="0"/>
+            <!-- <point>29.5,2,89.5</point> -->
         </region>
     </spawn>
 </spawns>


### PR DESCRIPTION
### Map Name
SuperCUBE

### Update Changelog
- Replaced `<block>` and `<cylinder>` regions with `<point>` for all spawns as players would sometimes get stuck and suffocate in their own spawn. **(outdated)**
- Centered the coordinates in `<cylinder>` regions and changed the height to be 0 so it can be consistent with spectator region.

Marking this pull request as draft as I am not able to test it on a server with both PGM and Mars installed at the moment.

### Screenshots or Videos (if applicable)
n/a
 
