### PR TITLE
Trenches: attempt to fix stalemates

### DIFF
--- a/CTF/Standard/Trenches/map.xml
+++ b/CTF/Standard/Trenches/map.xml
@@ -17,7 +17,7 @@
     <team id="blue" color="blue" max="24">Blue</team>
 </teams>
 <!-- Time Limit and Score -->
-<time>20m</time>
+<time>14m</time>
 <score>
     <limit>3</limit>
 </score>
@@ -42,7 +42,7 @@
         <chestplate unbreakable="true" color="3C44AA" material="leather chestplate"/>
     </kit>
     <kit id="flag-kit">
-        <max-health>12</max-health>
+        <max-health>14</max-health>
         <effect duration="3s" amplifier="3">absorption</effect>
     </kit>
 </kits>
@@ -85,11 +85,11 @@
 <!-- Flags -->
 <flags>
     <!-- Red's Flag -->
-    <post id="red-flag-post" pickup-filter="blue-only" recover-time="15s" respawn-time="10s">8,11,-86</post>
+    <post id="red-flag-post" pickup-filter="blue-only" recover-time="25s" respawn-time="10s">8,11,-86</post>
     <flag id="red-flag" owner="red" name="Red Flag" color="red" post="red-flag-post" carry-kit="flag-kit" beam="true"/>
     <net post="red-flag-post" points="1" region="blue-net" capture-filter="blue-only"/>
     <!-- Blue's Flag -->
-    <post id="blue-flag-post" pickup-filter="red-only" recover-time="15s" respawn-time="10s">-64,11,45</post>
+    <post id="blue-flag-post" pickup-filter="red-only" recover-time="25s" respawn-time="10s">-64,11,45</post>
     <flag id="blue-flag" owner="blue" name="Blue Flag" color="blue" post="blue-flag-post" carry-kit="flag-kit" beam="true"/>
     <net post="blue-flag-post" points="1" region="red-net" capture-filter="red-only"/>
 </flags>

--- a/CTF/Standard/Trenches/map.xml
+++ b/CTF/Standard/Trenches/map.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <map proto="1.4.0" game="Capture the Flag">
 <name>Trenches</name>
-<version>1.0.0</version>
+<version>1.0.1</version>
 <objective>First team to capture the enemy flag 3 times wins!</objective>
 <gamemode>ctf</gamemode>
 <authors>


### PR DESCRIPTION
### Map Name
Trenches
### Update Changelog
- Reduced time limit to 14 minutes
- Increased flag recovery time to 25 seconds
- Increased flag holder max health to 14 (7 hearts)

### Update Description
Not pushing directly so feedback can be given. These are some small (but relevant) changes to Trenches. Recently had a match with 25+ players on, but it slowly (and steadily) dropped down to a 10v10 as it progressed.

20 minutes is painfully long for this map, considering the large distance you have to traverse to get the flag. The 15s recovery time is simply not enough to get to the flag if it is dropped near the enemy's spawn, flag net, or even their own "trench" (side). Have also slightly boosted the flag-holder's max health to make a "run for it" or escape more feasible. 

Additionally, regions & filters currently allow you to build horrible stalemate-y defenses like the picture linked below.
I have not fixed that in this proposal but can totally do so if the rest agree or after the current time-related changes are tested.

### Screenshots or Videos (if applicable)
[Stalemate defense](https://i.imgur.com/O6oJzs8.jpeg)

