### PR TITLE
Brisked - easier hill capture and give golden apple per kill

### DIFF
--- a/KoTH/Standard/Brisked/map.xml
+++ b/KoTH/Standard/Brisked/map.xml
@@ -213,7 +213,7 @@
         </sticky>
     </rule>
 </falling-blocks>
-<control-points capture-time="12s" points="0.5" points-growth="480" capture-rule="lead" show-progress="true" required="false" decay="0.1" incremental="true">
+<control-points capture-time="12s" points="0.5" points-growth="480" capture-rule="lead" show-progress="true" required="false" incremental="true">
     <control-point id="hill-nw" name="North West Hill" capture="hill-nw-capture" progress="hill-nw-progress" captured="nw-jump-complete" />
     <control-point id="hill-se" name="South East Hill" capture="hill-se-capture" progress="hill-se-progress" captured="se-jump-complete" />
 </control-points>

--- a/KoTH/Standard/Brisked/map.xml
+++ b/KoTH/Standard/Brisked/map.xml
@@ -1,6 +1,6 @@
 <map proto="1.4.0">
 <name>Brisked</name>
-<version>1.0.14</version>
+<version>1.0.15</version>
 <objective>Collect the most points in 10 minutes!</objective>
 <gamemode>koth</gamemode>
 <authors>
@@ -213,7 +213,7 @@
         </sticky>
     </rule>
 </falling-blocks>
-<control-points capture-time="12s" points="0.5" points-growth="480" capture-rule="lead" show-progress="true" required="false" decay="0.1">
+<control-points capture-time="12s" points="0.5" points-growth="480" capture-rule="lead" show-progress="true" required="false" decay="0.1" incremental="true">
     <control-point id="hill-nw" name="North West Hill" capture="hill-nw-capture" progress="hill-nw-progress" captured="nw-jump-complete" />
     <control-point id="hill-se" name="South East Hill" capture="hill-se-capture" progress="hill-se-progress" captured="se-jump-complete" />
 </control-points>
@@ -248,9 +248,6 @@
     <item damage="1" amount="3" material="leaves" />
 </killreward>
 <killreward>
-    <filter>
-        <kill-streak count="2" repeat="true" />
-    </filter>
     <item material="golden apple" />
 </killreward>
 <killreward>

--- a/KoTH/Standard/Brisked/map.xml
+++ b/KoTH/Standard/Brisked/map.xml
@@ -213,7 +213,7 @@
         </sticky>
     </rule>
 </falling-blocks>
-<control-points capture-time="12s" points="0.5" points-growth="480" capture-rule="lead" show-progress="true" required="false" incremental="true">
+<control-points capture-time="9s" points="0.5" points-growth="480" capture-rule="lead" show-progress="true" required="false" decay="0.1" recovery-rate="0">
     <control-point id="hill-nw" name="North West Hill" capture="hill-nw-capture" progress="hill-nw-progress" captured="nw-jump-complete" />
     <control-point id="hill-se" name="South East Hill" capture="hill-se-capture" progress="hill-se-progress" captured="se-jump-complete" />
 </control-points>


### PR DESCRIPTION
### Map Name
Brisked

### Update Changelog

- Changed an option to make hills easier to capture by not resetting to 0% if an enemy walks over it.
- Give one golden apple per kill instead of every 2 kills
- Decreased hill capture time from 12 seconds to 9 seconds

### Screenshots or Videos (if applicable)
> n/a

(opened as a pull request since this was not tested yet)
 
