### PR TITLE
Limbo III: Decrease arrow kill reward

### DIFF
--- a/CTF/Standard/Limbo III/map.xml
+++ b/CTF/Standard/Limbo III/map.xml
@@ -1,6 +1,6 @@
 <map proto="1.4.2" game="King of the Flag">
 <name>Limbo III</name>
-<version>1.2.1</version>
+<version>1.2.2</version>
 <objective>Control the flag for 180 seconds to win!</objective>
 <gamemode>kotf</gamemode>
 <authors>

--- a/CTF/Standard/Limbo III/map.xml
+++ b/CTF/Standard/Limbo III/map.xml
@@ -112,7 +112,7 @@
 </itemkeep>
 <kill-reward>
     <item material="golden apple"/>
-    <item amount="8" material="arrow"/>
+    <item amount="4" material="arrow"/>
 </kill-reward>
 <respawn spectate="true" auto="true">
     <message>


### PR DESCRIPTION
One kill on Limbo III is not worth 8 arrows, it is an absurdly high amount of arrows to receive for a simple kill. 

The kill reward should be lowered to 4 arrows, to provide for less bow focused gameplay. 