### PR TITLE
Mark WZ editors as contributors on some maps

### DIFF
--- a/Infection/Bayview/map.xml
+++ b/Infection/Bayview/map.xml
@@ -1,17 +1,19 @@
 <map proto="1.4.0" game="Infection">
 <name>Bayview</name>
-<version>1.1.3</version>
+<version>1.1.4</version>
 <objective>Try not to get killed by the infected. Humans win by default after the timer ends.</objective>
 <gamemode>arcade</gamemode>
 <authors>
     <author uuid="27ac2daf-3c38-4b8e-9448-46f221bb612a"/> <!-- N11cK -->
     <author uuid="78d0a064-ffec-4820-b9e5-7a59a23458df"/> <!-- Sturmspitz -->
     <author uuid="53b3603c-4414-47b2-9667-18920279a9dc"/> <!-- patrickdemooij9 -->
-    <author uuid="39a9e1b5-1e1d-40c0-8c16-69a9568efa72"/> <!-- Teejers -->
-    <author uuid="c4ad59fd-a7c6-42f1-8a5f-5af0aa60353b"/> <!-- RedDemptr -->
 </authors>
+<contributors>
+    <contributor uuid="39a9e1b5-1e1d-40c0-8c16-69a9568efa72"/> <!-- Teejers -->
+    <contributor uuid="c4ad59fd-a7c6-42f1-8a5f-5af0aa60353b"/> <!-- RedDemptr -->
+</contributors>
 <teams>
-    <team id="human-team"    color="blue"  show-name-tags="allies" plural="true" min="3" max="50" max-overfill="50">Humans</team>
+    <team id="human-team" color="blue" show-name-tags="allies" plural="true" min="3" max="50" max-overfill="50">Humans</team>
     <team id="infected-team" color="green" show-name-tags="allies" plural="true" min="1" max="5" max-overfill="5">Infected</team>
 </teams>
 <time result="human-team">7m</time>

--- a/Infection/Grind/map.xml
+++ b/Infection/Grind/map.xml
@@ -1,16 +1,18 @@
 <map proto="1.4.0" game="Infection">
 <name>Grind</name>
-<version>1.1.2</version>
+<version>1.1.3</version>
 <objective>Try not to get killed by the infected. Humans win by default after the timer ends.</objective>
 <gamemode>arcade</gamemode>
 <authors>
     <author uuid="27ac2daf-3c38-4b8e-9448-46f221bb612a"/> <!-- N11cK -->
-    <author uuid="39a9e1b5-1e1d-40c0-8c16-69a9568efa72"/> <!-- Teejers -->
-    <author uuid="c4ad59fd-a7c6-42f1-8a5f-5af0aa60353b"/> <!-- RedDemptr -->
-    <author uuid="db3e4ab9-7c34-4342-8aca-63db60ec8d1b"/> <!-- slees -->
 </authors>
+<contributors>
+    <contributor uuid="39a9e1b5-1e1d-40c0-8c16-69a9568efa72"/> <!-- Teejers -->
+    <contributor uuid="c4ad59fd-a7c6-42f1-8a5f-5af0aa60353b"/> <!-- RedDemptr -->
+    <contributor uuid="db3e4ab9-7c34-4342-8aca-63db60ec8d1b"/> <!-- slees -->
+</contributors>
 <teams>
-    <team id="human-team"    color="blue"  show-name-tags="allies" plural="true" min="3" max="50" max-overfill="50">Humans</team>
+    <team id="human-team" color="blue" show-name-tags="allies" plural="true" min="3" max="50" max-overfill="50">Humans</team>
     <team id="infected-team" color="green" show-name-tags="allies" plural="true" min="1" max="5" max-overfill="5">Infected</team>
 </teams>
 <time result="human-team">7m</time>

--- a/Infection/Meltdown/map.xml
+++ b/Infection/Meltdown/map.xml
@@ -1,16 +1,18 @@
 <map proto="1.4.0" game="Infection">
 <name>Meltdown</name>
-<version>1.1.2</version>
+<version>1.1.3</version>
 <objective>Try not to get killed by the infected. Humans win by default after the timer ends.</objective>
 <gamemode>arcade</gamemode>
 <authors>
     <author uuid="27ac2daf-3c38-4b8e-9448-46f221bb612a"/> <!-- N11cK -->
-    <author uuid="39a9e1b5-1e1d-40c0-8c16-69a9568efa72"/> <!-- Teejers -->
-    <author uuid="c4ad59fd-a7c6-42f1-8a5f-5af0aa60353b"/> <!-- RedDemptr -->
-    <author uuid="db3e4ab9-7c34-4342-8aca-63db60ec8d1b"/> <!-- slees -->
 </authors>
+<contributors>
+    <contributor uuid="39a9e1b5-1e1d-40c0-8c16-69a9568efa72"/> <!-- Teejers -->
+    <contributor uuid="c4ad59fd-a7c6-42f1-8a5f-5af0aa60353b"/> <!-- RedDemptr -->
+    <contributor uuid="db3e4ab9-7c34-4342-8aca-63db60ec8d1b"/> <!-- slees -->
+</contributors>
 <teams>
-    <team id="human-team"    color="blue"  show-name-tags="allies" plural="true" min="3" max="50" max-overfill="50">Humans</team>
+    <team id="human-team" color="blue" show-name-tags="allies" plural="true" min="3" max="50" max-overfill="50">Humans</team>
     <team id="infected-team" color="green" show-name-tags="allies" plural="true" min="1" max="5" max-overfill="5">Infected</team>
 </teams>
 <time result="human-team">7m</time>

--- a/Infection/Nuke/map.xml
+++ b/Infection/Nuke/map.xml
@@ -1,15 +1,17 @@
 <map proto="1.4.0" game="Infection">
 <name>Nuke</name>
-<version>1.1.2</version>
+<version>1.1.3</version>
 <objective>Try not to get killed by the infected. Humans win by default after the timer ends.</objective>
 <gamemode>arcade</gamemode>
 <authors>
     <author uuid="27ac2daf-3c38-4b8e-9448-46f221bb612a"/> <!-- N11cK -->
-    <author uuid="39a9e1b5-1e1d-40c0-8c16-69a9568efa72"/> <!-- Teejers -->
-    <author uuid="c4ad59fd-a7c6-42f1-8a5f-5af0aa60353b"/> <!-- RedDemptr -->
 </authors>
+<contributors>
+    <contributor uuid="39a9e1b5-1e1d-40c0-8c16-69a9568efa72"/> <!-- Teejers -->
+    <contributor uuid="c4ad59fd-a7c6-42f1-8a5f-5af0aa60353b"/> <!-- RedDemptr -->
+</contributors>
 <teams>
-    <team id="human-team"    color="blue"  show-name-tags="allies" plural="true" min="3" max="50" max-overfill="50">Humans</team>
+    <team id="human-team" color="blue" show-name-tags="allies" plural="true" min="3" max="50" max-overfill="50">Humans</team>
     <team id="infected-team" color="green" show-name-tags="allies" plural="true" min="1" max="5" max-overfill="5">Infected</team>
 </teams>
 <time result="human-team">7m</time>

--- a/Infection/Plaza/map.xml
+++ b/Infection/Plaza/map.xml
@@ -1,16 +1,18 @@
 <map proto="1.4.0" game="Infection">
 <name>Plaza</name>
-<version>1.2.1</version>
+<version>1.2.2</version>
 <objective>Try not to get killed by the infected. Humans win by default after the timer ends.</objective>
 <gamemode>arcade</gamemode>
 <authors>
     <author uuid="27ac2daf-3c38-4b8e-9448-46f221bb612a"/> <!-- N11cK -->
-    <author uuid="39a9e1b5-1e1d-40c0-8c16-69a9568efa72"/> <!-- Teejers -->
-    <author uuid="c4ad59fd-a7c6-42f1-8a5f-5af0aa60353b"/> <!-- RedDemptr -->
-    <author uuid="3f9e78fe-18bd-478c-a0b2-305198d23a0a"/> <!-- MatrixTunnel -->
 </authors>
+<contributors>
+    <contributor uuid="39a9e1b5-1e1d-40c0-8c16-69a9568efa72"/> <!-- Teejers -->
+    <contributor uuid="c4ad59fd-a7c6-42f1-8a5f-5af0aa60353b"/> <!-- RedDemptr -->
+    <contributor uuid="3f9e78fe-18bd-478c-a0b2-305198d23a0a"/> <!-- MatrixTunnel -->
+</contributors>
 <teams>
-    <team id="human-team"    color="blue"  show-name-tags="allies" plural="true" min="3" max="50" max-overfill="50">Humans</team>
+    <team id="human-team" color="blue" show-name-tags="allies" plural="true" min="3" max="50" max-overfill="50">Humans</team>
     <team id="infected-team" color="green" show-name-tags="allies" plural="true" min="1" max="5" max-overfill="5">Infected</team>
 </teams>
 <time result="human-team">7m</time>

--- a/Infection/Raid/map.xml
+++ b/Infection/Raid/map.xml
@@ -1,17 +1,19 @@
 <map proto="1.4.2" game="Infection">
 <name>Raid</name>
-<version>1.2.5</version>
+<version>1.2.6</version>
 <objective>Try not to get killed by the infected. Humans win by default after the timer ends.</objective>
 <gamemode>arcade</gamemode>
 <authors>
     <author uuid="27ac2daf-3c38-4b8e-9448-46f221bb612a"/> <!-- N11cK -->
-    <author uuid="39a9e1b5-1e1d-40c0-8c16-69a9568efa72"/> <!-- Teejers -->
-    <author uuid="811968c3-0a9f-4cb5-80af-19ce37141341"/> <!-- BennyDoesStuff -->
-    <author uuid="42195cb9-b21b-42f5-b938-5ef46f303fcd"/> <!-- _Bill -->
-    <author uuid="b13b0b00-a8f9-422b-8963-b3d18bf80aa6"/> <!-- Bearinx -->
 </authors>
+<contributors>
+    <contributor uuid="39a9e1b5-1e1d-40c0-8c16-69a9568efa72"/> <!-- Teejers -->
+    <contributor uuid="811968c3-0a9f-4cb5-80af-19ce37141341"/> <!-- BennyDoesStuff -->
+    <contributor uuid="42195cb9-b21b-42f5-b938-5ef46f303fcd"/> <!-- _Bill -->
+    <contributor uuid="b13b0b00-a8f9-422b-8963-b3d18bf80aa6"/> <!-- Bearinx -->
+</contributors>
 <teams>
-    <team id="human-team"    color="blue"  show-name-tags="allies" plural="true" min="3" max="50" max-overfill="50">Humans</team>
+    <team id="human-team" color="blue" show-name-tags="allies" plural="true" min="3" max="50" max-overfill="50">Humans</team>
     <team id="infected-team" color="green" show-name-tags="allies" plural="true" min="1" max="5" max-overfill="5">Infected</team>
 </teams>
 <time result="human-team">7m</time>

--- a/Infection/StrikeZone/map.xml
+++ b/Infection/StrikeZone/map.xml
@@ -1,16 +1,18 @@
 <map proto="1.4.0" game="Infection">
 <name>StrikeZone</name>
-<version>1.1.1</version>
+<version>1.1.2</version>
 <objective>Try not to get killed by the infected. Humans win by default after the timer ends.</objective>
 <gamemode>arcade</gamemode>
 <authors>
     <author uuid="27ac2daf-3c38-4b8e-9448-46f221bb612a"/> <!-- N11cK -->
-    <author uuid="42195cb9-b21b-42f5-b938-5ef46f303fcd"/> <!-- _Bill -->
-    <author uuid="6b093498-6541-447a-bee6-9615484f1350"/> <!-- EERRR8KKJ -->
-		<author uuid="811968c3-0a9f-4cb5-80af-19ce37141341"/> <!-- BennyDoesStuff -->
 </authors>
+<contributors>
+    <contributor uuid="42195cb9-b21b-42f5-b938-5ef46f303fcd"/> <!-- _Bill -->
+    <contributor uuid="6b093498-6541-447a-bee6-9615484f1350"/> <!-- EERRR8KKJ -->
+    <contributor uuid="811968c3-0a9f-4cb5-80af-19ce37141341"/> <!-- BennyDoesStuff -->
+</contributors>
 <teams>
-    <team id="human-team"    color="blue"  show-name-tags="allies" plural="true" min="3" max="50" max-overfill="50">Humans</team>
+    <team id="human-team" color="blue" show-name-tags="allies" plural="true" min="3" max="50" max-overfill="50">Humans</team>
     <team id="infected-team" color="green" show-name-tags="allies" plural="true" min="1" max="5" max-overfill="5">Infected</team>
 </teams>
 <time result="human-team">7m</time>

--- a/Infection/Yowzer Stadium/map.xml
+++ b/Infection/Yowzer Stadium/map.xml
@@ -5,13 +5,13 @@
 <gamemode>arcade</gamemode>
 <authors>
     <author uuid="db3e4ab9-7c34-4342-8aca-63db60ec8d1b"/> <!-- slees -->
-		<author uuid="4e55a4a3-9b70-4a0a-b4ed-b81415ae7b80"/> <!-- draemworks -->
-		<author uuid="a22f2197-5992-4e69-a483-5e5f7a44a0ad"/> <!-- Piinoy -->
-		<author uuid="c78d4660-635a-417c-ad28-b432b6804f6b"/> <!-- Pndq -->
-		<author uuid="d2f13c61-eacc-46c2-893f-ffaff81486f6"/> <!-- Moia -->
+    <author uuid="4e55a4a3-9b70-4a0a-b4ed-b81415ae7b80"/> <!-- draemworks -->
+    <author uuid="a22f2197-5992-4e69-a483-5e5f7a44a0ad"/> <!-- Piinoy -->
+    <author uuid="c78d4660-635a-417c-ad28-b432b6804f6b"/> <!-- Pndq -->
+    <author uuid="d2f13c61-eacc-46c2-893f-ffaff81486f6"/> <!-- Moia -->
 </authors>
 <teams>
-    <team id="human-team"    color="blue"  show-name-tags="allies" plural="true" min="3" max="50" max-overfill="50">Humans</team>
+    <team id="human-team" color="blue" show-name-tags="allies" plural="true" min="3" max="50" max-overfill="50">Humans</team>
     <team id="infected-team" color="green" show-name-tags="allies" plural="true" min="1" max="5" max-overfill="5">Infected</team>
 </teams>
 <time result="human-team">7m</time>


### PR DESCRIPTION
It was brought to my attention that these maps improperly marked the original builder and Warzone members that have remixed these maps as both authors rather than dividing them into authors and contributors separately. This was most likely due to TGM not having the ability to label people as contributors, which was then overlooked when these maps were ported to PGM.