### PR TITLE
Survival Games updates

### DIFF
--- a/Includes/survival-games.xml
+++ b/Includes/survival-games.xml
@@ -1,18 +1,20 @@
 <!-- Base "Survival Games" include -->
 <!-- Created by TheBestGamer, _Pear, Fishywishi, et al. -->
-<!-- Include version 1.2.1 -->
+<!-- Include version 1.3.0 -->
 <map>
 <gamemode>sg</gamemode>
 <objective>Be the last player standing.</objective>
 <constants fallback="true"> <!-- Default values - Can be overriden by an individual map's code -->
     <constant id="timelimit">13m</constant> <!-- Match ending time -->
-    <constant id="deathmatch-teleport">1m</constant> <!-- How long until players are teleported to the deathmatch-->
-    <constant id="deathmatch-start">1m10s</constant> <!-- How long until the deathmatch starts (after teleporting) -->
+    <constant id="deathmatch-pre-teleport">10m45s</constant> <!-- How long until players are warned for teleport to deathmatch -->
+    <constant id="deathmatch-teleport">11m</constant> <!-- How long until players are teleported to the deathmatch -->
+    <constant id="deathmatch-start">11m15s</constant> <!-- How long until the deathmatch starts (after teleporting) -->
     <constant id="player-count">24</constant> <!-- How many players this map is suited for based on podium counts. Common values: "8", "12", "24", "32", "48" -->
     <constant id="grace-period">15s</constant> <!-- Controls how long the grace period is -->
     <constant id="chest-refill-timer">4m</constant> <!-- How often chests will be refilled-->
     <constant id="match-delay">10s</constant>
 </constants>
+<include id="sound-keys"/>
 <time>${timelimit}</time>
 <blitz>
     <lives>1</lives>
@@ -26,10 +28,12 @@
         </not>
         <match-running/>
     </all>
+    <time id="deathmatch-pre-teleport-time">${deathmatch-pre-teleport}</time>
     <time id="deathmatch-teleport-time">${deathmatch-teleport}</time>
     <time id="deathmatch-start-time">${deathmatch-start}</time>
     <countdown id="grace-period-countdown" duration="${grace-period}" message="Grace period will end in {0}" filter="starting-countdown"/>
-    <countdown id="deathmatch-countdown" duration="10s" message="`c{0} until deathmatch!" filter="deathmatch-teleport-time"/>
+    <countdown id="deathmatch-teleport-countdown" duration="15s" message="`cYou will be teleported to the deathmatch in {0}" filter="deathmatch-pre-teleport-time"/>
+    <countdown id="deathmatch-countdown" duration="15s" message="`c{0} until deathmatch!" filter="deathmatch-teleport-time"/>
     <pulse id="chest-refill" period="${chest-refill-timer}" duration="1s" filter="match-started"/>
     <any id="allow-break">
         <material>leaves</material>
@@ -76,6 +80,7 @@
     </trigger>
     <trigger scope="player">
         <action scope="player">
+            <sound key="${entity.lightning_bolt.thunder}" volume="0.2"/>
             <message text="`8`l[`6`lSG`8`l] `3Grace period is now over!"/>
         </action>
         <filter>
@@ -98,7 +103,30 @@
             </all>
         </filter>
     </trigger>
-    <!--
+    <trigger scope="player">
+        <action scope="player">
+            <message text="`8`l[`6`lSG`8`l] `c10 minutes until deathmatch!"/>
+        </action>
+        <filter>
+            <time>1m</time>
+        </filter>
+    </trigger>
+    <trigger scope="player">
+        <action scope="player">
+            <message text="`8`l[`6`lSG`8`l] `c5 minutes until deathmatch!"/>
+        </action>
+        <filter>
+            <time>6m</time>
+        </filter>
+    </trigger>
+    <trigger scope="player">
+        <action scope="player">
+            <message text="`8`l[`6`lSG`8`l] `c15 seconds until deathmatch!"/>
+        </action>
+        <filter>
+            <time>10m45s</time>
+        </filter>
+    </trigger>
     <trigger filter="dead" scope="player">
         <action scope="player">
             <switch-scope outer="player" inner="match">
@@ -108,7 +136,6 @@
             </switch-scope>
         </action>
     </trigger>
-    -->
     <trigger filter="match-finished" scope="match">
         <action scope="match">
             <message text="`8`l[`6`lSG`8`l] `aThe games have ended!"/>
@@ -116,13 +143,14 @@
     </trigger>
     <trigger filter="deathmatch-start-time" scope="match">
         <action scope="match">
+            <message text="`8`l[`6`lSG`8`l] `cDeathmatch has started!"/>
             <message text="`8`l[`6`lSG`8`l] `cFight to the death!"/>
         </action>
     </trigger>
     <trigger filter="deathmatch-teleport-time" scope="match">
         <action>
             <switch-scope inner="player">
-                <teleport x="tp_points_x[tribute] + 0.5" y="tp_points_y[tribute]" z="tp_points_z[tribute] + 0.5"/>
+                <teleport x="tp_points_x[tribute]" y="tp_points_y[tribute]" z="tp_points_z[tribute]"/>
             </switch-scope>
         </action>
     </trigger>

--- a/Includes/survival-games.xml
+++ b/Includes/survival-games.xml
@@ -102,6 +102,7 @@
     <variable id="tribute"/>
 </variables>
 <variables scope="match">
+    <variable id="cages" default="1"/>
     <variable id="remaining"/>
     <variable id="tmp"/>
     <array id="tp_points_x" size="${player-count}" />
@@ -121,8 +122,9 @@
         </action>
     </trigger>
     <!-- Announces the start of the games after the starting countdown ends -->
-    <trigger filter="starting-countdown" scope="player">
+    <trigger scope="player" filter="starting-countdown">
         <action scope="player">
+            <set var="cages" value="0"/>
             <sound key="${entity.lightning_bolt.thunder}" volume="0.2"/>
             <message text="`8`l[`6`lSG`8`l] `3Happy Survival Games!"/>
             <message text="`8`l[`6`lSG`8`l] `3And may the odds be ever in your favor."/>
@@ -181,22 +183,24 @@
         </filter>
     </trigger>
     <!-- Teleports players to spawn points for deathmatch -->
-    <trigger filter="deathmatch-teleport-time" scope="match">
+    <trigger scope="match" filter="deathmatch-teleport-time">
         <action>
+            <set var="cages" value="1"/>
             <switch-scope inner="player">
                 <teleport x="tp_points_x[tribute]" y="tp_points_y[tribute]" z="tp_points_z[tribute]"/>
             </switch-scope>
         </action>
     </trigger>
     <!-- Announces the start of the deathmatch -->  
-    <trigger filter="deathmatch-start-time" scope="match">
+    <trigger scope="match" filter="deathmatch-start-time">
         <action scope="match">
+            <set var="cages" value="0"/>
             <message text="`8`l[`6`lSG`8`l] `cDeathmatch has started!"/>
             <message text="`8`l[`6`lSG`8`l] `cFight to the death!"/>
         </action>
     </trigger>
     <!-- Announces the end of the games -->
-    <trigger filter="match-finished" scope="match">
+    <trigger scope="match" filter="match-finished">
         <action scope="match">
             <message text="`8`l[`6`lSG`8`l] `aThe games have ended!"/>
         </action>
@@ -214,10 +218,9 @@
             <message text="`8`l[`6`lSG`8`l] `6A cannon can be heard in the distance." />
         </switch-scope>
     </action>
-    <trigger filter="all(not(participating), not(match-finished), match-started)" action="player-killed" scope="player" observers="true"/>
+    <trigger scope="player" filter="all(not(participating), not(match-finished), match-started)" action="player-killed" observers="true"/>
 </actions>
 <regions>
-    <!-- <apply leave="starting-countdown" region="spawn-cages"/> -->
     <apply block="allow-break" block-place="always"/>
 </regions>
 <lootables>

--- a/Includes/survival-games.xml
+++ b/Includes/survival-games.xml
@@ -5,10 +5,10 @@
 <gamemode>sg</gamemode>
 <objective>Be the last player standing.</objective>
 <constants fallback="true"> <!-- Default values - Can be overriden by an individual map's code -->
-    <constant id="timelimit">10m</constant>
+    <constant id="timelimit">13m</constant> <!-- Match ending time -->
+    <constant id="deathmatch-teleport">1m</constant> <!-- How long until players are teleported to the deathmatch-->
+    <constant id="deathmatch-start">1m10s</constant> <!-- How long until the deathmatch starts (after teleporting) -->
     <constant id="player-count">24</constant> <!-- How many players this map is suited for based on podium counts. Common values: "8", "12", "24", "32", "48" -->
-    <constant id="world-border-on">always</constant> <!-- Controls world border message. Can be set to "never" to turn off -->
-    <constant id="world-border-time">4</constant>
     <constant id="grace-period">15s</constant> <!-- Controls how long the grace period is -->
     <constant id="chest-refill-timer">4m</constant> <!-- How often chests will be refilled-->
     <constant id="match-delay">10s</constant>
@@ -19,17 +19,17 @@
     <broadcastLives>false</broadcastLives>
 </blitz>
 <players min="8" max="${player-count}" max-overfill="${player-count}" colors="true"/> <!-- max-overfill should always be the same as max, otherwise maps will run out of spawn slot for players and break -->
-<broadcasts>
-    <alert after="${world-border-time}m" filter="${world-border-on}">The world border has begun to shrink!</alert>
-</broadcasts>
 <filters>
     <all id="starting-countdown">
         <not>
-            <countdown duration="${match-delay}" message="`3`lMatch will start in {0}" filter="match-running"/>
+            <countdown duration="${match-delay}" message="`c{0} until the games begin!" filter="match-running"/>
         </not>
         <match-running/>
     </all>
+    <time id="deathmatch-teleport-time">${deathmatch-teleport}</time>
+    <time id="deathmatch-start-time">${deathmatch-start}</time>
     <countdown id="grace-period-countdown" duration="${grace-period}" message="Grace period will end in {0}" filter="starting-countdown"/>
+    <countdown id="deathmatch-countdown" duration="10s" message="`c{0} until deathmatch!" filter="deathmatch-teleport-time"/>
     <pulse id="chest-refill" period="${chest-refill-timer}" duration="1s" filter="match-started"/>
     <any id="allow-break">
         <material>leaves</material>
@@ -57,15 +57,26 @@
         <region id="tier-2-chests"/>
     </all>
 </filters>
+<variables scope="player">
+    <variable id="tribute"/>
+</variables>
+<variables scope="match">
+    <variable id="tmp"/>
+    <array id="tp_points_x" size="${player-count}" />
+    <array id="tp_points_y" size="${player-count}" />
+    <array id="tp_points_z" size="${player-count}" />
+</variables>
 <actions>
     <trigger filter="starting-countdown" scope="player">
         <action scope="player">
-            <message text="`7`l[`6`lSurvival `e`lGames`7`l] `3The games have started!"/>
+            <sound key="ambient.weather.thunder" volume="0.2"/>
+            <message text="`8`l[`6`lSG`8`l] `3Happy Survival Games!"/>
+            <message text="`8`l[`6`lSG`8`l] `3And may the odds be ever in your favor."/>
         </action>
     </trigger>
     <trigger scope="player">
         <action scope="player">
-            <message text="`7`l[`6`lSurvival `e`lGames`7`l] `3Grace Period is now over!"/>
+            <message text="`8`l[`6`lSG`8`l] `3Grace period is now over!"/>
         </action>
         <filter>
             <all>
@@ -78,7 +89,7 @@
     </trigger>
     <trigger scope="player">
         <action scope="player">
-            <message text="`7`l[`6`lSurvival `e`lGames`7`l] `3Chests have been refilled!"/>
+            <message text="`8`l[`6`lSG`8`l] `3Chests have been refilled!"/>
         </action>
         <filter>
             <all>
@@ -86,6 +97,42 @@
                 <time>${chest-refill-timer}</time>
             </all>
         </filter>
+    </trigger>
+    <!--
+    <trigger filter="dead" scope="player">
+        <action scope="player">
+            <switch-scope outer="player" inner="match">
+                <sound key="ambient.weather.thunder" volume="0.2"/>
+                <message text="`8`l[`6`lSG`8`l] `aOnly `8[`6${}`8] `atributes remain!" />
+                <message text="`8`l[`6`lSG`8`l] `6A cannon can be heard in the distance." />
+            </switch-scope>
+        </action>
+    </trigger>
+    -->
+    <trigger filter="match-finished" scope="match">
+        <action scope="match">
+            <message text="`8`l[`6`lSG`8`l] `aThe games have ended!"/>
+        </action>
+    </trigger>
+    <trigger filter="deathmatch-start-time" scope="match">
+        <action scope="match">
+            <message text="`8`l[`6`lSG`8`l] `cFight to the death!"/>
+        </action>
+    </trigger>
+    <trigger filter="deathmatch-teleport-time" scope="match">
+        <action>
+            <switch-scope inner="player">
+                <teleport x="tp_points_x[tribute] + 0.5" y="tp_points_y[tribute]" z="tp_points_z[tribute] + 0.5"/>
+            </switch-scope>
+        </action>
+    </trigger>
+    <trigger scope="match" filter="match-started">
+        <action>
+            <switch-scope inner="player">
+                <set var="tribute" value="tmp" />
+                <set var="tmp" value="tmp + 1" />
+            </switch-scope>
+        </action>
     </trigger>
 </actions>
 <regions>
@@ -225,9 +272,6 @@
             </option>
             <option weight="15">
                 <item material="wood sword" unbreakable="true"/>
-            </option>
-            <option weight="15">
-                <item material="iron sword" unbreakable="true"/>
             </option>
             <option weight="15">
                 <item material="bow" unbreakable="true"/>

--- a/Includes/survival-games.xml
+++ b/Includes/survival-games.xml
@@ -69,7 +69,7 @@
 <actions>
     <trigger filter="starting-countdown" scope="player">
         <action scope="player">
-            <sound key="ambient.weather.thunder" volume="0.2"/>
+            <sound key="${entity.lightning_bolt.thunder}" volume="0.2"/>
             <message text="`8`l[`6`lSG`8`l] `3Happy Survival Games!"/>
             <message text="`8`l[`6`lSG`8`l] `3And may the odds be ever in your favor."/>
         </action>
@@ -102,7 +102,7 @@
     <trigger filter="dead" scope="player">
         <action scope="player">
             <switch-scope outer="player" inner="match">
-                <sound key="ambient.weather.thunder" volume="0.2"/>
+                <sound key="${entity.lightning_bolt.thunder}" volume="0.2"/>
                 <message text="`8`l[`6`lSG`8`l] `aOnly `8[`6${}`8] `atributes remain!" />
                 <message text="`8`l[`6`lSG`8`l] `6A cannon can be heard in the distance." />
             </switch-scope>

--- a/Includes/survival-games.xml
+++ b/Includes/survival-games.xml
@@ -1,6 +1,43 @@
 <!-- Base "Survival Games" include -->
 <!-- Created by TheBestGamer, _Pear, Fishywishi, et al. -->
 <!-- Include version 1.3.0 -->
+<!-- 
+    To adequately use this include and properly set up your map, some requirements must be met:
+
+    1. At the start of the match, players must be trapped in spawn cages. These are defined in
+    the map.xml in the form of cylinder regions. One cage per spawn point is required.
+
+    Example:
+
+    <union id="spawn-cages">
+        <cylinder base="-1576.5,60,-635.5" radius="1" height="2"/>
+    </union>
+
+    2. In order to teleport players to the deathmatch, actions to set teleport variables must be defined.
+    Three variables with increasing indexes are defined per spawn point.
+
+    Example:
+
+    <actions>
+        <trigger scope="match" filter="always">
+            <action>
+                <set var="tp_points_x" index="0" value="-1576" />
+                <set var="tp_points_y" index="0" value="60" />
+                <set var="tp_points_z" index="0" value="-635" />
+            </action>
+        </trigger>
+    </actions>
+
+    3. To avoid players escaping the deathmatch, first set up a world border around the entire map.
+    Quickly reduce it in size to prevent exiting spawn once players are teleported to the deathmatch.
+
+    Example:
+
+    <world-borders center="-1577,-611">
+        <world-border size="1050"/>
+        <world-border size="56" after="${deathmatch-teleport}" duration="1s"/>
+    </world-borders>
+-->
 <map>
 <gamemode>sg</gamemode>
 <objective>Be the last player standing.</objective>
@@ -12,7 +49,7 @@
     <constant id="player-count">24</constant> <!-- How many players this map is suited for based on podium counts. Common values: "8", "12", "24", "32", "48" -->
     <constant id="grace-period">15s</constant> <!-- Controls how long the grace period is -->
     <constant id="chest-refill-timer">4m</constant> <!-- How often chests will be refilled-->
-    <constant id="match-delay">10s</constant>
+    <constant id="match-delay">10s</constant> <!-- How long before players are released from their spawn cages -->
 </constants>
 <include id="sound-keys"/>
 <time>${timelimit}</time>
@@ -71,6 +108,16 @@
     <array id="tp_points_z" size="${player-count}" />
 </variables>
 <actions>
+    <!-- Keeps track of alive players and sets up TP coordinates for deathmatch -->
+    <trigger scope="match" filter="match-started">
+        <action>
+            <switch-scope inner="player">
+                <set var="tribute" value="tmp" />
+                <set var="tmp" value="tmp + 1" />
+            </switch-scope>
+        </action>
+    </trigger>
+    <!-- Announces the start of the games after the starting countdown ends -->
     <trigger filter="starting-countdown" scope="player">
         <action scope="player">
             <sound key="${entity.lightning_bolt.thunder}" volume="0.2"/>
@@ -78,6 +125,7 @@
             <message text="`8`l[`6`lSG`8`l] `3And may the odds be ever in your favor."/>
         </action>
     </trigger>
+    <!-- Announces the end of the grace period -->
     <trigger scope="player">
         <action scope="player">
             <sound key="${entity.lightning_bolt.thunder}" volume="0.2"/>
@@ -92,6 +140,7 @@
             </all>
         </filter>
     </trigger>
+    <!-- Announces that chests have been refilled -->
     <trigger scope="player">
         <action scope="player">
             <message text="`8`l[`6`lSG`8`l] `3Chests have been refilled!"/>
@@ -103,6 +152,7 @@
             </all>
         </filter>
     </trigger>
+    <!-- Announcements for time left until deathmatch -->
     <trigger scope="player">
         <action scope="player">
             <message text="`8`l[`6`lSG`8`l] `c10 minutes until deathmatch!"/>
@@ -127,26 +177,7 @@
             <time>10m45s</time>
         </filter>
     </trigger>
-    <trigger filter="dead" scope="player">
-        <action scope="player">
-            <switch-scope outer="player" inner="match">
-                <sound key="${entity.lightning_bolt.thunder}" volume="0.2"/>
-                <message text="`8`l[`6`lSG`8`l] `aOnly `8[`6${}`8] `atributes remain!" />
-                <message text="`8`l[`6`lSG`8`l] `6A cannon can be heard in the distance." />
-            </switch-scope>
-        </action>
-    </trigger>
-    <trigger filter="match-finished" scope="match">
-        <action scope="match">
-            <message text="`8`l[`6`lSG`8`l] `aThe games have ended!"/>
-        </action>
-    </trigger>
-    <trigger filter="deathmatch-start-time" scope="match">
-        <action scope="match">
-            <message text="`8`l[`6`lSG`8`l] `cDeathmatch has started!"/>
-            <message text="`8`l[`6`lSG`8`l] `cFight to the death!"/>
-        </action>
-    </trigger>
+    <!-- Teleports players to spawn points for deathmatch -->
     <trigger filter="deathmatch-teleport-time" scope="match">
         <action>
             <switch-scope inner="player">
@@ -154,14 +185,32 @@
             </switch-scope>
         </action>
     </trigger>
-    <trigger scope="match" filter="match-started">
-        <action>
-            <switch-scope inner="player">
-                <set var="tribute" value="tmp" />
-                <set var="tmp" value="tmp + 1" />
-            </switch-scope>
+    <!-- Announces the start of the deathmatch -->  
+    <trigger filter="deathmatch-start-time" scope="match">
+        <action scope="match">
+            <message text="`8`l[`6`lSG`8`l] `cDeathmatch has started!"/>
+            <message text="`8`l[`6`lSG`8`l] `cFight to the death!"/>
         </action>
     </trigger>
+    <!-- Announces the end of the games -->
+    <trigger filter="match-finished" scope="match">
+        <action scope="match">
+            <message text="`8`l[`6`lSG`8`l] `aThe games have ended!"/>
+        </action>
+    </trigger>
+    <!-- Sends messages when a player is killed -->
+    <action id="player-killed" scope="player">
+        <set var="tmp" value="tmp - 1"/>
+        <switch-scope outer="player" inner="match">
+            <sound key="${entity.lightning_bolt.thunder}" volume="0.2"/>
+            <message text="`8`l[`6`lSG`8`l] `aOnly `8[`6{remaining-players}`8] `atributes remain!">
+                <replacements>
+                    <decimal id="remaining-players" value="tmp"/>
+                </replacements>
+            </message>
+            <message text="`8`l[`6`lSG`8`l] `6A cannon can be heard in the distance." />
+        </switch-scope>
+    </action>
 </actions>
 <regions>
     <!-- <apply leave="starting-countdown" region="spawn-cages"/> -->
@@ -420,6 +469,9 @@
         </all>
     </deny>
 </damage>
+<kill-rewards>
+    <kill-reward victim-action="player-killed"/>  
+</kill-rewards>
 <itemremove>
     <item>sapling</item>
     <item>seeds</item>

--- a/Includes/survival-games.xml
+++ b/Includes/survival-games.xml
@@ -102,6 +102,7 @@
     <variable id="tribute"/>
 </variables>
 <variables scope="match">
+    <variable id="remaining"/>
     <variable id="tmp"/>
     <array id="tp_points_x" size="${player-count}" />
     <array id="tp_points_y" size="${player-count}" />
@@ -111,7 +112,9 @@
     <!-- Keeps track of alive players and sets up TP coordinates for deathmatch -->
     <trigger scope="match" filter="match-started">
         <action>
+            <set var="remaining" value="0"/>
             <switch-scope inner="player">
+                <set var="remaining" value="remaining + 1"/>
                 <set var="tribute" value="tmp" />
                 <set var="tmp" value="tmp + 1" />
             </switch-scope>
@@ -200,17 +203,18 @@
     </trigger>
     <!-- Sends messages when a player is killed -->
     <action id="player-killed" scope="player">
-        <set var="tmp" value="tmp - 1"/>
+        <set var="remaining" value="remaining - 1"/>
         <switch-scope outer="player" inner="match">
             <sound key="${entity.lightning_bolt.thunder}" volume="0.2"/>
             <message text="`8`l[`6`lSG`8`l] `aOnly `8[`6{remaining-players}`8] `atributes remain!">
                 <replacements>
-                    <decimal id="remaining-players" value="tmp"/>
+                    <decimal id="remaining-players" value="remaining"/>
                 </replacements>
             </message>
             <message text="`8`l[`6`lSG`8`l] `6A cannon can be heard in the distance." />
         </switch-scope>
     </action>
+    <trigger filter="all(not(participating), not(match-finished), match-started)" action="player-killed" scope="player" observers="true"/>
 </actions>
 <regions>
     <!-- <apply leave="starting-countdown" region="spawn-cages"/> -->
@@ -470,7 +474,7 @@
     </deny>
 </damage>
 <kill-rewards>
-    <kill-reward victim-action="player-killed"/>  
+    <kill-reward filter="not(remaining=2)" victim-action="player-killed"/>  
 </kill-rewards>
 <itemremove>
     <item>sapling</item>


### PR DESCRIPTION
Survival Games updates in order to more closely represent the original MCSG experience.

So far:

- [x] Replace world border logic for deathmatch teleportation logic
  - This requires modifying each `map.xml` to set up actions that set teleport variables.
    Three variables with increasing indexes are defined per spawn point.
    Example:
```xml
    <actions>
        <trigger scope="match" filter="always">
            <action>
                <set var="tp_points_x" index="0" value="-1576" />
                <set var="tp_points_y" index="0" value="60" />
                <set var="tp_points_z" index="0" value="-635" />
            </action>
        </trigger>
    </actions>
```
- [x] Fixing messages & sound sent for death/kill
- [x] Reenabling cages for 10 seconds after players are teleported to deathmatch
  - Leave filter for the `spawn-cages` region must be set to `cages=0` at the `map.xml`
```xml 
<apply leave="cages=0" region="spawn-cages"/>
```
- [x] Messages for time left until the deathmatch
- [x] ~~Creating a region or dome to enclose players at spawn for deathmatch~~
  - This is better handled using the world border module at the `map.xml` instead of the include. First, the world border should be the size of the entire map, then quickly reduced in size to enclose players at spawn when they are teleported.
```xml
<world-borders center="-1577,-611">
    <world-border size="1050"/>
    <world-border size="56" after="${deathmatch-teleport}" duration="1s"/>
</world-borders>
```
- [x] Update include version as desired
- [x] Test all of the above