### PR TITLE
Update Loot Tables

### DIFF
--- a/Includes/survival-games.xml
+++ b/Includes/survival-games.xml
@@ -409,6 +409,18 @@ The last tribute standing wins.
                 <item material="golden apple"/>
             </option>
             <!-- Armor -->
+            <option weight="20">
+                <item material="leather helmet"/>
+            </option>
+            <option weight="15">
+                <item material="leather chestplate"/>
+            </option>
+            <option weight="15">
+                <item material="leather leggings"/>
+            </option>
+            <option weight="20">
+                <item material="leather boots"/>
+            </option>
             <option weight="15">
                 <item material="gold helmet"/>
             </option>

--- a/Includes/survival-games.xml
+++ b/Includes/survival-games.xml
@@ -227,16 +227,19 @@ The last tribute standing wins.
 </regions>
 <lootables>
     <loot id="tier-1-chests-loottable">
-        <any count="2..5" unique="true">
+        <any count="3..6" unique="true">
             <!-- Weapons -->
             <option weight="20">
                 <item material="stone sword" unbreakable="true"/>
             </option>
-            <option weight="25">
+            <option weight="20">
                 <item material="stone axe" unbreakable="true"/>
             </option>
             <option weight="25">
                 <item material="wood sword" unbreakable="true"/>
+            </option>
+            <option weight="25">
+                <item material="wood axe" unbreakable="true"/>
             </option>
             <option weight="15">
                 <item material="bow" unbreakable="true"/>
@@ -312,6 +315,18 @@ The last tribute standing wins.
             <option weight="15">
                 <item material="gold boots"/>
             </option>
+            <option weight="15">
+                <item material="chainmail helmet"/>
+            </option>
+            <option weight="10">
+                <item material="chainmail chestplate"/>
+            </option>
+            <option weight="10">
+                <item material="chainmail leggings"/>
+            </option>
+            <option weight="15">
+                <item material="chainmail boots"/>
+            </option>
             <option weight="5">
                 <item material="iron helmet"/>
             </option>
@@ -319,22 +334,22 @@ The last tribute standing wins.
                 <item material="iron boots"/>
             </option>
             <!-- Items -->
-            <option weight="10">
+            <option weight="15">
                 <item material="stick"/>
             </option>
-            <option weight="8">
+            <option weight="12">
                 <item material="iron ingot"/>
             </option>
-            <option weight="8">
+            <option weight="15">
                 <item material="gold ingot"/>
             </option>
-            <option weight="8">
+            <option weight="12">
                 <item material="feather"/>
             </option>
-            <option weight="10">
+            <option weight="12">
                 <item material="flint"/>
             </option>
-            <option weight="5">
+            <option weight="6">
                 <item material="diamond"/>
             </option>
             <any>
@@ -355,9 +370,6 @@ The last tribute standing wins.
             </option>
             <option weight="25">
                 <item material="stone axe" unbreakable="true"/>
-            </option>
-            <option weight="15">
-                <item material="wood sword" unbreakable="true"/>
             </option>
             <option weight="15">
                 <item material="bow" unbreakable="true"/>
@@ -397,18 +409,6 @@ The last tribute standing wins.
                 <item material="golden apple"/>
             </option>
             <!-- Armor -->
-            <option weight="20">
-                <item material="leather helmet"/>
-            </option>
-            <option weight="15">
-                <item material="leather chestplate"/>
-            </option>
-            <option weight="15">
-                <item material="leather leggings"/>
-            </option>
-            <option weight="20">
-                <item material="leather boots"/>
-            </option>
             <option weight="15">
                 <item material="gold helmet"/>
             </option>
@@ -420,6 +420,18 @@ The last tribute standing wins.
             </option>
             <option weight="18">
                 <item material="gold boots"/>
+            </option>
+            <option weight="15">
+                <item material="chainmail helmet"/>
+            </option>
+            <option weight="15">
+                <item material="chainmail chestplate"/>
+            </option>
+            <option weight="15">
+                <item material="chainmail leggings"/>
+            </option>
+            <option weight="18">
+                <item material="chainmail boots"/>
             </option>
             <option weight="10">
                 <item material="iron helmet"/>
@@ -434,19 +446,19 @@ The last tribute standing wins.
                 <item material="iron boots"/>
             </option>
             <!-- Items -->
-            <option weight="10">
+            <option weight="15">
                 <item material="stick"/>
             </option>
-            <option weight="12">
+            <option weight="15">
                 <item material="iron ingot"/>
             </option>
             <option weight="12">
                 <item material="gold ingot"/>
             </option>
-            <option weight="6">
+            <option weight="12">
                 <item material="feather"/>
             </option>
-            <option weight="10">
+            <option weight="12">
                 <item material="flint"/>
             </option>
             <option weight="8">


### PR DESCRIPTION
Updated Loot table

- Increased item count in tier one chests from 2-5 to 3-6
- Added chainmail armor to both tiers of chest
- Increased odds for materials
- Added wooden axes to weapons

Need more feedback to continue improving the loot tables