### PR TITLE
Fixing Pistons not working

### DIFF
--- a/Includes/survival-games.xml
+++ b/Includes/survival-games.xml
@@ -94,7 +94,9 @@
         <material>double plant</material>
         <material>long grass</material>
         <material>dead bush</material>
+        <material>fire</material>
     </any>
+    <cause id="player-cause">player</cause>
     <any id="chests">
         <material>chest</material>
         <material>trapped chest</material>
@@ -230,7 +232,7 @@
     <trigger scope="player" filter="all(not(participating), not(match-finished), match-started)" action="player-killed" observers="false"/>
 </actions>
 <regions>
-    <apply block="allow-break" block-place="always"/>
+    <apply block="deny(all(player-cause, not(allow-break)))" />
 </regions>
 <lootables>
     <loot id="tier-1-chests-loottable">


### PR DESCRIPTION
Fix for pistons not pushing or pulling in survival games. Also allowing to break and place fire.